### PR TITLE
Memoize hookname generation

### DIFF
--- a/lib/named-hooks.js
+++ b/lib/named-hooks.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var _cloneDeep = require('lodash.clonedeep'),
+var _memoize = require('lodash.memoize'),
+    _cloneDeep = require('lodash.clonedeep'),
     q = require('q'),
     debug = require('debug')('named-hooks:named-hooks');
 
@@ -14,17 +15,17 @@ function NamedHooks(name) {
   this.namespace = new Namespace();
 }
 
-NamedHooks.prototype.init = function (folder) {
+NamedHooks.prototype.init = function init(folder) {
   debug('#init: loading named-hooks for namespace "%s" from folder "%s"', this.name, folder);
   this.namespace.load(folder);
 };
 
-NamedHooks.prototype.defineHookResolutionRules = function (callback) {
+NamedHooks.prototype.defineHookResolutionRules = function defineHookResolutionRules(callback) {
   this.getPossibleHookNames = callback;
   debug('#defineHookResolutionRules: using function with name "%s" to define hook resolution rules', callback.name);
 };
 
-NamedHooks.prototype.getPossibleHookNames = function (hookName, identifier) {
+NamedHooks.prototype._getPossibleHookNames = function _getPossibleHookNames(hookName, identifier) {
   if (!hookName) {
     debug('#getPossibleHookNames: no base hookName given. Returning empty array');
     return [];
@@ -45,7 +46,18 @@ NamedHooks.prototype.getPossibleHookNames = function (hookName, identifier) {
   return possibleHookNames;
 };
 
-NamedHooks.prototype.invokeSync = function (hookName, identifier, data) {
+// create wrapper function so it's possible to spy on it in tests
+NamedHooks.prototype.getPossibleHookNames = function getPossibleHookNames(hookName, identifier) {
+  return this._getPossibleHookNames(hookName, identifier);
+};
+
+// memoize internal `#_getPossibleHookNames`
+// and define lookup key unique key as "`hookName` + '$' + `identifier`" string
+NamedHooks.prototype.getPossibleHookNames = _memoize(NamedHooks.prototype.getPossibleHookNames, function (hookName, identifier) {
+  return hookName + '$' + identifier;
+});
+
+NamedHooks.prototype.invokeSync = function invokeSync(hookName, identifier, data) {
   var possibleHookNames = this.getPossibleHookNames(hookName, identifier),
       result = _cloneDeep(data),
       existingFunctionNames = this._getExistingFunctionNames(possibleHookNames);
@@ -60,7 +72,7 @@ NamedHooks.prototype.invokeSync = function (hookName, identifier, data) {
   return result;
 };
 
-NamedHooks.prototype.invoke = function (hookName, identifier, data, context) {
+NamedHooks.prototype.invoke = function invoke(hookName, identifier, data, context) {
   var possibleHookNames = this.getPossibleHookNames(hookName, identifier),
       existingFunctions = this._getExistingFunctions(possibleHookNames),
       existingFunctionNames = this._getExistingFunctionNames(possibleHookNames),
@@ -86,7 +98,7 @@ NamedHooks.prototype.invoke = function (hookName, identifier, data, context) {
 //    q(5)
 //      .then(namedHooks.invoke.bind(namedHooks, 'hookName', 'indentifier'))
 //      .then(console.log);
-NamedHooks.prototype.invokeChain = function (hookName, identifier, context) {
+NamedHooks.prototype.invokeChain = function invokeChain(hookName, identifier, context) {
   var possibleHookNames = this.getPossibleHookNames(hookName, identifier),
       existingFunctionNames = this._getExistingFunctionNames(possibleHookNames),
       existingFunctions = this._getExistingFunctions(possibleHookNames);
@@ -132,14 +144,13 @@ function _mapHookCalls(hooks, context) {
   });
 }
 
-NamedHooks.prototype._getExistingFunctions = function (possibleHookNames) {
-
+NamedHooks.prototype._getExistingFunctions = function _getExistingFunctions(possibleHookNames) {
   return this._getExistingFunctionNames(possibleHookNames).map(function (hookName) {
     return this.namespace.hooks[hookName];
   }, this);
 };
 
-NamedHooks.prototype._getExistingFunctionNames = function (possibleHookNames) {
+NamedHooks.prototype._getExistingFunctionNames = function _getExistingFunctionNames(possibleHookNames) {
   var existingFunctionNames = [];
 
   possibleHookNames.forEach(function (hookName) {

--- a/lib/named-hooks.js
+++ b/lib/named-hooks.js
@@ -9,6 +9,10 @@ var Namespace = require('./namespace');
 
 var namespaces = {};
 
+var _memoizeKeyResolution = function (hookName, identifier) {
+  return hookName + '$' + identifier;
+};
+
 function NamedHooks(name) {
   this.name = name;
   debug('created new namespace "%s"', name);
@@ -21,7 +25,7 @@ NamedHooks.prototype.init = function init(folder) {
 };
 
 NamedHooks.prototype.defineHookResolutionRules = function defineHookResolutionRules(callback) {
-  this.getPossibleHookNames = callback;
+  this.getPossibleHookNames = _memoize(callback, _memoizeKeyResolution);
   debug('#defineHookResolutionRules: using function with name "%s" to define hook resolution rules', callback.name);
 };
 
@@ -53,9 +57,7 @@ NamedHooks.prototype.getPossibleHookNames = function getPossibleHookNames(hookNa
 
 // memoize internal `#_getPossibleHookNames`
 // and define lookup key unique key as "`hookName` + '$' + `identifier`" string
-NamedHooks.prototype.getPossibleHookNames = _memoize(NamedHooks.prototype.getPossibleHookNames, function (hookName, identifier) {
-  return hookName + '$' + identifier;
-});
+NamedHooks.prototype.getPossibleHookNames = _memoize(NamedHooks.prototype.getPossibleHookNames, _memoizeKeyResolution);
 
 NamedHooks.prototype.invokeSync = function invokeSync(hookName, identifier, data) {
   var possibleHookNames = this.getPossibleHookNames(hookName, identifier),
@@ -90,13 +92,13 @@ NamedHooks.prototype.invoke = function invoke(hookName, identifier, data, contex
 // crazy bindings
 // i.e.:
 //    q(5)
-//      .then(namedHooks.invokeChain('hookName', 'indentifier'))
+//      .then(namedHooks.invokeChain('hookName', 'identifier'))
 //      .then(console.log);
 //
 // as opposed to:
 // i.e. (crazy binding):
 //    q(5)
-//      .then(namedHooks.invoke.bind(namedHooks, 'hookName', 'indentifier'))
+//      .then(namedHooks.invoke.bind(namedHooks, 'hookName', 'identifier'))
 //      .then(console.log);
 NamedHooks.prototype.invokeChain = function invokeChain(hookName, identifier, context) {
   var possibleHookNames = this.getPossibleHookNames(hookName, identifier),

--- a/lib/named-hooks.js
+++ b/lib/named-hooks.js
@@ -22,9 +22,13 @@ function NamedHooks(name) {
 NamedHooks.prototype.init = function init(folder) {
   debug('#init: loading named-hooks for namespace "%s" from folder "%s"', this.name, folder);
   this.namespace.load(folder);
+
+  // invalidate memoization cache
+  NamedHooks.prototype.getPossibleHookNames = _memoize(getPossibleHookNames, _memoizeKeyResolution);
 };
 
 NamedHooks.prototype.defineHookResolutionRules = function defineHookResolutionRules(callback) {
+  // memoize new resolution callback
   this.getPossibleHookNames = _memoize(callback, _memoizeKeyResolution);
   debug('#defineHookResolutionRules: using function with name "%s" to define hook resolution rules', callback.name);
 };
@@ -51,13 +55,13 @@ NamedHooks.prototype._getPossibleHookNames = function _getPossibleHookNames(hook
 };
 
 // create wrapper function so it's possible to spy on it in tests
-NamedHooks.prototype.getPossibleHookNames = function getPossibleHookNames(hookName, identifier) {
+function getPossibleHookNames(hookName, identifier) {
   return this._getPossibleHookNames(hookName, identifier);
 };
 
 // memoize internal `#_getPossibleHookNames`
 // and define lookup key unique key as "`hookName` + '$' + `identifier`" string
-NamedHooks.prototype.getPossibleHookNames = _memoize(NamedHooks.prototype.getPossibleHookNames, _memoizeKeyResolution);
+NamedHooks.prototype.getPossibleHookNames = _memoize(getPossibleHookNames, _memoizeKeyResolution);
 
 NamedHooks.prototype.invokeSync = function invokeSync(hookName, identifier, data) {
   var possibleHookNames = this.getPossibleHookNames(hookName, identifier),

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "debug": "^2.2.0",
     "lodash.clonedeep": "^3.0.2",
+    "lodash.memoize": "^3.0.4",
     "q": "^1.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "named-hooks",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Define and invoke hooks based on function names",
   "main": "index.js",
   "directories": {

--- a/test/named-hooks-test.js
+++ b/test/named-hooks-test.js
@@ -118,6 +118,16 @@ describe('NamedHooks', function () {
 
       assert.deepEqual(result1, result2);
     });
+
+    it('memoization is invalidated when `#init` is called', function () {
+      namedHooks.getPossibleHookNames('hookName5', 'ID-foo-bar');
+
+      namedHooks.init(path.resolve('./test/namespace-mock-folder'));
+
+      namedHooks.getPossibleHookNames('hookName5', 'ID-foo-bar');
+
+      sinon.assert.calledTwice(spy);
+    });
   });
 
   describe('#defineHookResolutionRules(callback)', function () {
@@ -150,6 +160,18 @@ describe('NamedHooks', function () {
       namedHooks.getPossibleHookNames('hookName4', 'ID-foo-bar');
 
       sinon.assert.calledOnce(spy);
+    });
+
+    it('invalidates memoization cache', function () {
+      var spy = sinon.spy();
+
+      namedHooks.defineHookResolutionRules(spy);
+      namedHooks.getPossibleHookNames('hookName5', 'ID-foo-bar');
+
+      namedHooks.defineHookResolutionRules(spy);
+      namedHooks.getPossibleHookNames('hookName5', 'ID-foo-bar');
+
+      sinon.assert.calledTwice(spy);
     });
   });
 

--- a/test/named-hooks-test.js
+++ b/test/named-hooks-test.js
@@ -125,12 +125,10 @@ describe('NamedHooks', function () {
       delete namedHooks.getPossibleHookNames;
     });
 
-    it('sets `getPossibleHookNames` with `callback`', function () {
-      var getPossibleHookNames = function () {};
-
-      namedHooks.defineHookResolutionRules(getPossibleHookNames);
-
-      assert.equal(namedHooks.getPossibleHookNames, getPossibleHookNames);
+    it('throws if `callback` is not a function', function () {
+      assert.throws(function () {
+        namedHooks.defineHookResolutionRules(123);
+      });
     });
 
     it('`#getPossibleHookNames` returns [ "hai" ] if `callback` returns [ "hai" ]', function () {
@@ -141,6 +139,17 @@ describe('NamedHooks', function () {
       namedHooks.defineHookResolutionRules(getPossibleHookNames);
 
       assert.deepEqual(namedHooks.getPossibleHookNames(), [ 'hai' ]);
+    });
+
+    it('memoization keeps working', function () {
+      var spy = sinon.spy();
+
+      namedHooks.defineHookResolutionRules(spy);
+
+      namedHooks.getPossibleHookNames('hookName4', 'ID-foo-bar');
+      namedHooks.getPossibleHookNames('hookName4', 'ID-foo-bar');
+
+      sinon.assert.calledOnce(spy);
     });
   });
 

--- a/test/named-hooks-test.js
+++ b/test/named-hooks-test.js
@@ -68,6 +68,16 @@ describe('NamedHooks', function () {
   });
 
   describe('#getPossibleHookNames(hookName, identifier)', function () {
+    var spy;
+
+    beforeEach(function () {
+      spy = sinon.spy(namedHooks, '_getPossibleHookNames');
+    });
+
+    afterEach(function () {
+      spy.restore();
+    });
+
     it('returns empty Array if `hookName` is `undefined`', function () {
       assert.deepEqual(namedHooks.getPossibleHookNames(), []);
     });
@@ -86,6 +96,27 @@ describe('NamedHooks', function () {
 
     it('returns [ "hookName", "hookNameID", "hookNamefoo", "hookNamefoobar", "hookNameIDfoobar" ] if `identifier` is `ID-foo-bar`', function () {
       assert.deepEqual(namedHooks.getPossibleHookNames('hookName', 'ID-foo-bar'), [ "hookName", "hookNameID", "hookNamefoo", "hookNamebar", "hookNameIDfoobar" ]);
+    });
+
+    it('memoizes the result', function () {
+      namedHooks.getPossibleHookNames('hookName2', 'ID-foo-bar');
+      namedHooks.getPossibleHookNames('hookName2', 'ID-foo-bar');
+
+      sinon.assert.calledOnce(spy);
+    });
+
+    it('memoization key is `hookName` + `identifier`', function () {
+      namedHooks.getPossibleHookNames('hookName3', 'ID'),
+      namedHooks.getPossibleHookNames('hookName3', 'ID-foo');
+
+      sinon.assert.calledTwice(spy);
+    });
+
+    it('memoized result is exactly the same', function () {
+      var result1 = namedHooks.getPossibleHookNames('hookName4', 'ID-foo-bar'),
+          result2 = namedHooks.getPossibleHookNames('hookName4', 'ID-foo-bar');
+
+      assert.deepEqual(result1, result2);
     });
   });
 


### PR DESCRIPTION
- Possible hook names generation is memoized with `_.memoize`
- Cache is invalidated on `#init` and `#defineHookResolutionRules` (any method that updates loaded hooks into the namespace)
